### PR TITLE
Config 전역변수 정리 #1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,20 @@
       "email": "kt.kang@ridi.com"
     }
   ],
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "git@gitlab.ridi.io:common/php-core.git"
+    }
+  ],
   "require": {
     "gnf/gnfcache": "^0.1.0",
     "illuminate/database": "^5.2"
   },
   "require-dev": {
-    "silex/silex": "^1.3"
+    "ridibooks/core": "dev-master",
+    "silex/silex": "^1.3",
+    "twig/twig": "^1.0.0"
   },
   "autoload": {
     "psr-4": {

--- a/index.php
+++ b/index.php
@@ -5,7 +5,11 @@ use Ridibooks\Platform\Cms\MiniRouter;
 use Ridibooks\Platform\Cms\UserControllerProvider;
 use Symfony\Component\HttpFoundation\Request;
 
-require_once __DIR__ . '/../config.php';
+if (is_readable(__DIR__ . '/../config.php')) {
+    require_once __DIR__ . '/../config.php';
+} elseif (is_readable(__DIR__ . '/config.local.php')) {
+    require_once __DIR__ . '/config.local.php';
+}
 
 $autoloader = require __DIR__ . "/vendor/autoload.php";
 
@@ -17,7 +21,7 @@ $app = new CmsApplication();
 
 // Try MiniRouter first
 $app->before(function (Request $request) {
-	return MiniRouter::shouldRedirectForLogin($request);
+	return MiniRouter::shouldRedirectForLogin($request, false);
 });
 
 $app->mount('/', new UserControllerProvider());

--- a/src/Cms/Auth/LoginService.php
+++ b/src/Cms/Auth/LoginService.php
@@ -72,13 +72,17 @@ class LoginService
 
 	public static function startSession()
 	{
-		if (\Config::$COUCHBASE_ENABLE) {
-			session_set_save_handler(
-				new CouchbaseSessionHandler(implode(',', \Config::$COUCHBASE_SERVER_HOSTS), 'session', self::SESSION_TIMEOUT_SEC),
-				true
-			);
-		}
-		session_set_cookie_params(self::SESSION_TIMEOUT_SEC, '/', \Config::$ADMIN_DOMAIN);
+		session_set_cookie_params(self::SESSION_TIMEOUT_SEC, '/', $_SERVER['SERVER_NAME']);
 		session_start();
+	}
+
+	public static function startCouchbaseSession($server_hosts)
+	{
+		session_set_save_handler(
+			new CouchbaseSessionHandler(implode(',', $server_hosts), 'session', self::SESSION_TIMEOUT_SEC),
+			true
+		);
+
+		self::startSession();
 	}
 }

--- a/src/Cms/MiniRouter.php
+++ b/src/Cms/MiniRouter.php
@@ -1,7 +1,6 @@
 <?php
 namespace Ridibooks\Platform\Cms;
 
-use Ridibooks\Library\DB\Profiler;
 use Ridibooks\Platform\Cms\Auth\AdminAuthService;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -157,17 +156,12 @@ class MiniRouter
 		/** @var \Twig_Environment $twig_helper */
 		$twig_helper = $app['twig'];
 
-		$response_str = $twig_helper->render($view_file_name, $args);
-		if (\Config::$ENABLE_DB_LOGGER && !$request->isXmlHttpRequest()) {
-			$response_str .= Profiler::getCombinedHtml();
-		}
-
-		return Response::create($response_str);
+		return Response::create($twig_helper->render($view_file_name, $args));
 	}
 
 	private static function notFound()
 	{
-		return Response::create('<meta http-equiv="refresh" content="5;url=' . htmlspecialchars('http://' . \Config::$ADMIN_DOMAIN) .
+		return Response::create('<meta http-equiv="refresh" content="5;url=' . htmlspecialchars('http://' . $_SERVER['HTTP_HOST']) .
 			'"> 페이지를 찾을 수 없습니다. URL이 변경되었을 수 있습니다. 오류라고 생각되시면 담당자에게 문의해 주세요.<br />' .
 			'5초 후 자동으로 메인 페이지로 이동합니다.', Response::HTTP_NOT_FOUND);
 	}

--- a/src/Cms/MiniRouter.php
+++ b/src/Cms/MiniRouter.php
@@ -26,9 +26,10 @@ class MiniRouter
 
 	/**
 	 * @param Request $request
+	 * @param bool $enable_ssl
 	 * @return Response
 	 */
-	public function route(Request $request)
+	public function route(Request $request, $enable_ssl = true)
 	{
 		$request_uri_wo_qs = self::getNormalizedUri($request->getRequestUri());
 
@@ -53,7 +54,7 @@ class MiniRouter
 			$controller_path = substr($request_uri_wo_qs, strlen($this->prefix_uri));
 		}
 
-		$response = self::shouldRedirectForLogin($request);
+		$response = self::shouldRedirectForLogin($request, $enable_ssl);
 		if ($response) {
 			return $response;
 		}
@@ -76,11 +77,12 @@ class MiniRouter
 
 	/**
 	 * @param Request $request
+	 * @param bool $enable_ssl
 	 * @return null|Response
 	 */
-	public static function shouldRedirectForLogin(Request $request)
+	public static function shouldRedirectForLogin(Request $request, $enable_ssl = true)
 	{
-		$response = self::conformAllowedProtocol($request);
+		$response = self::conformAllowedProtocol($request, $enable_ssl);
 		if ($response) {
 			return $response;
 		}
@@ -99,11 +101,11 @@ class MiniRouter
 		return null;
 	}
 
-	private static function conformAllowedProtocol(Request $request)
+	private static function conformAllowedProtocol(Request $request, $enable_ssl)
 	{
-		if (\Config::$ENABLE_SSL && !self::onHttps($request)) {
+		if ($enable_ssl && !self::onHttps($request)) {
 			return RedirectResponse::create('https://' . $request->getHttpHost() . $request->getRequestUri());
-		} elseif (!\Config::$ENABLE_SSL && self::onHttps($request)) {
+		} elseif (!$enable_ssl && self::onHttps($request)) {
 			return RedirectResponse::create('http://' . $request->getHttpHost() . $request->getRequestUri());
 		}
 


### PR DESCRIPTION
전부 정리하지는 못했고, 아래 Config 에서 사용되는 변수는 외부에서 선언해 주어야 합니다.


```php
class Config
{
    public static $DB_PARAMS = [];

    public static $DOMAIN;
    public static $MISC_URL;
    public static $ACTIVE_URL;
    public static $HTTP_HOST_LINK;
    public static $SSL_HOST_LINK;

    public static $UNDER_DEV = true;

    public static function getConnectionParams($name)
    {
        if (isset(static::$DB_PARAMS[$name])) {
            return static::$DB_PARAMS[$name];
        }

        if (!isset(static::$DB_PARAMS['default'])) {
            throw new \Exception("Default DB connection parameters are missing.");
        }

        return static::$DB_PARAMS['default'];
    }
}
```

업그레이드시 하위호환 이슈가 발생하며, 아래와 같이 수정이 필요합니다.

1.
LoginService::startSession()
 => LoginService::startCouchbaseSession(\Config::$COUCHBASE_SERVER_HOSTS)


2.
$app['debug'] = \Config::$UNDER_DEV;


3.
MiniRouter::shouldRedirectForLogin($request, \Config::$ENABLE_SSL);
$router->route($request, \Config::$ENABLE_SSL);
