### PR TITLE
Unignore sample deploy target specification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 vendor
 static/bower_components
 docs/deploy/servers/*
+!docs/deploy/servers/sample.yml


### PR DESCRIPTION
Fixes the following PhpStorm warning:

> Ignored files found that are tracked: .ignore plugin found some files that are tracked with Git which are also listed in .gitignore file.