### PR TITLE
Add AdminMenuService::getAllUserIds.

### DIFF
--- a/src/Model/AdminMenu.php
+++ b/src/Model/AdminMenu.php
@@ -36,6 +36,16 @@ class AdminMenu extends Model
         );
     }
 
+    public function tags()
+    {
+        return $this->belongsToMany(
+            AdminTag::class,
+            'tb_admin2_tag_menu',
+            'menu_id',
+            'tag_id'
+        );
+    }
+
     public function ajaxMenus()
     {
         return $this->hasMany(AdminMenuAjax::class, 'menu_id');

--- a/src/Service/AdminMenuService.php
+++ b/src/Service/AdminMenuService.php
@@ -58,4 +58,28 @@ class AdminMenuService implements AdminMenuServiceIf
 
         return $menu->users->pluck('id')->all();
     }
+
+    public function getAllUserIds($menu_id)
+    {
+        /** @var AdminMenu $menu */
+        $menu = AdminMenu::find($menu_id);
+        if (!$menu) {
+            return [];
+        }
+
+        // 1: menu.tags.users
+        $tags_users = $menu->tags
+            ->map(function ($tag) {
+                return $tag->users->pluck('id');
+            })
+            ->collapse()
+            ->all();
+
+        // 2: menu:users
+        $menu_users = $menu->users->pluck('id')->all();
+
+        $user_ids = array_unique(array_merge($tags_users, $menu_users));
+        return $user_ids;
+    }
+
 }


### PR DESCRIPTION
https://app.asana.com/0/235684600038401/381445095289849/f
태그로 권한이 관리되면서, 계정에 메뉴 권한이 직접적으로 할당되진 않았지만 해당 메뉴가 포함된 태그가 등록되면서 간접적으로 권한이 부여되는 경우가 있습니다.
이런 경우를 고려해서 전체 유저를 검색하는 기능이 없었기 때문에 이번에 추가했습니다.