### PR TITLE
Fix AdminMenuService::getAllUserIds not to return unused ids

### DIFF
--- a/src/Service/AdminMenuService.php
+++ b/src/Service/AdminMenuService.php
@@ -70,13 +70,13 @@ class AdminMenuService implements AdminMenuServiceIf
         // 1: menu.tags.users
         $tags_users = $menu->tags
             ->map(function ($tag) {
-                return $tag->users->pluck('id');
+                return $tag->users->where('is_use', 1)->pluck('id');
             })
             ->collapse()
             ->all();
 
         // 2: menu:users
-        $menu_users = $menu->users->pluck('id')->all();
+        $menu_users = $menu->users->where('is_use', 1)->pluck('id')->all();
 
         $user_ids = array_unique(array_merge($tags_users, $menu_users));
         return $user_ids;


### PR DESCRIPTION
**Issue**:
  https://app.asana.com/0/235684600038401/381445095289849/f

**Changed**:
  I added a condition checking is_use=1 at the function.

**How to test**:
  - Run`curl -d '[1,"AdminMenu:getAllUserIds",1,0,{"1":{"i32":[TAG ID]}}]' -H "Accept: application/x-thrift" -X POST [CMS TEST HOST]`. (Replace [TAG ID] and [CMS TEST HOST] to test value)
  - Check the result whether it contains only ids which is_use=1.