### PR TITLE
Release v1.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM ridibooks/performance-apache-base:latest
+MAINTAINER Kang Ki Tae <kt.kang@ridi.com>
+
+ADD . /var/www/html
+WORKDIR /var/www/html
+RUN make all

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all: build composer
 
 build:
-	bower install
+	bower install --allow-root
 
 composer:
 	composer install --no-dev --optimize-autoloader

--- a/health.php
+++ b/health.php
@@ -1,0 +1,3 @@
+<?php
+
+exit($_SERVER['SERVER_NAME']);

--- a/src/Service/AdminMenuService.php
+++ b/src/Service/AdminMenuService.php
@@ -70,13 +70,13 @@ class AdminMenuService implements AdminMenuServiceIf
         // 1: menu.tags.users
         $tags_users = $menu->tags
             ->map(function ($tag) {
-                return $tag->users->pluck('id');
+                return $tag->users->where('is_use', 1)->pluck('id');
             })
             ->collapse()
             ->all();
 
         // 2: menu:users
-        $menu_users = $menu->users->pluck('id')->all();
+        $menu_users = $menu->users->where('is_use', 1)->pluck('id')->all();
 
         $user_ids = array_unique(array_merge($tags_users, $menu_users));
         return $user_ids;


### PR DESCRIPTION
### Summary
Fix getAllUserIds not to return unused ids.
Add a health check page and Dockerfile.

### Change List
Add Dockerfile. (#21) |  ec7b31378c76f373233255692cc6429a54add39b
Add health.php (#24) | 13238fdbe24aaa1949a5a386b30eb4a337b4ad8c
Fix AdminMenuService::getAllUserIds to return ids in used. (#23) | 285143d6d3b2982c52714c59e513e3c3fe41e731